### PR TITLE
Filtering of entries

### DIFF
--- a/back-end/src/api/routers/hackers_news_filter_request.py
+++ b/back-end/src/api/routers/hackers_news_filter_request.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class HackersNewsFilterRequest(str, Enum):
+    TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC = "title_words_greater_than_five_order_by_comments_desc"
+    TITLE_WORDS_LESS_THAN_OR_EQUALS_TO_FIVE_ORDER_BY_POINTS_DESC = "title_words_less_than_or_equals_to_five_order_by_points_desc"

--- a/back-end/src/api/routers/hackers_news_router.py
+++ b/back-end/src/api/routers/hackers_news_router.py
@@ -1,15 +1,44 @@
-from typing import List
+from typing import List, Optional
 from fastapi import APIRouter, Depends
 from src.api.di import get_news_entries_scraping_service
+from src.api.routers.hackers_news_filter_request import HackersNewsFilterRequest
 from src.api.routers.hackers_news_response import HackerNewsResponse, HackerNewsResponseAdapter
+from src.services.filtering.filtering_builder import FilterBuilder
 from src.services.news_entries_scraping.news_entries_scraping_service import NewsEntriesScrapingService
+from src.utils.title_word_counter import count_title_words
 
 
 router = APIRouter(prefix="/hacker-news-entries", tags=["Hacker News"])
 
 
 @router.get("/")
-def get_hackers_news(news_entries_scraping_service: NewsEntriesScrapingService = Depends(get_news_entries_scraping_service)) -> List[HackerNewsResponse]:
-    return HackerNewsResponseAdapter.to_hacker_news_responses(
-        news_entries_scraping_service.get_entries()
-    )
+def get_hackers_news(
+    filter_request: Optional[HackersNewsFilterRequest] = None,
+    news_entries_scraping_service: NewsEntriesScrapingService = Depends(
+        get_news_entries_scraping_service)
+) -> List[HackerNewsResponse]:
+    entries = news_entries_scraping_service.get_entries()
+
+    if filter_request is None:
+        return HackerNewsResponseAdapter.to_hacker_news_responses(entries)
+
+    filtering_builder = FilterBuilder(entries)
+
+    if filter_request == HackersNewsFilterRequest.TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC:
+        entries = filtering_builder.where(
+            lambda entry: count_title_words(entry.title) > 5
+        ).order_by(
+            lambda entry: entry.comments_count,
+            reverse=True
+        ).execute_filter()
+
+    elif filter_request == HackersNewsFilterRequest.TITLE_WORDS_LESS_OR_EQUAL_THAN_FIVE_ORDER_BY_POINTS_DESC:
+        entries = filtering_builder.where(
+            lambda entry: count_title_words(entry.title) <= 5
+        ).order_by(
+            lambda entry: entry.points,
+            reverse=True
+        ).execute_filter()
+
+    return HackerNewsResponseAdapter.to_hacker_news_responses(entries)
+

--- a/back-end/src/api/routers/hackers_news_router.py
+++ b/back-end/src/api/routers/hackers_news_router.py
@@ -32,7 +32,7 @@ def get_hackers_news(
             reverse=True
         ).execute_filter()
 
-    elif filter_request == HackersNewsFilterRequest.TITLE_WORDS_LESS_OR_EQUAL_THAN_FIVE_ORDER_BY_POINTS_DESC:
+    elif filter_request == HackersNewsFilterRequest.TITLE_WORDS_LESS_THAN_OR_EQUALS_TO_FIVE_ORDER_BY_POINTS_DESC:
         entries = filtering_builder.where(
             lambda entry: count_title_words(entry.title) <= 5
         ).order_by(

--- a/back-end/src/services/filtering/filtering_builder.py
+++ b/back-end/src/services/filtering/filtering_builder.py
@@ -1,0 +1,45 @@
+from enum import Enum
+from typing import Callable, List, Tuple, Union
+
+from src.models.news_entry import NewsEntry
+
+
+class Operation(Enum):
+    SORT = 1,
+    FILTER = 2
+
+
+class FilterBuilder:
+    def __init__(self, entries: List[NewsEntry]):
+        self.__entries = entries
+        self.__operations: List[
+            Tuple[
+                Union[
+                    Callable[[NewsEntry], bool],
+                    Tuple[Callable[[NewsEntry], Union[int, float, str]], bool]],
+
+                Operation
+            ]
+        ] = []
+
+    def where(self, function: Callable[[NewsEntry], bool]):
+        self.__operations.append((function, Operation.FILTER))
+        return self
+
+    def order_by(self, function: Callable[[NewsEntry], Union[int, float, str]], reverse: bool = False):
+        self.__operations.append(((function, reverse), Operation.SORT))
+        return self
+
+    def execute_filter(self) -> List[NewsEntry]:
+
+        for function, operation in self.__operations:
+            if operation == Operation.SORT:
+                sort_function, reverse = function
+                self.__entries = list(sorted(self.__entries, key=sort_function, reverse=reverse))
+                continue
+            if operation == Operation.FILTER:
+                self.__entries = list(
+                    filter(function, self.__entries))
+                continue
+
+        return list(self.__entries)

--- a/back-end/src/utils/title_word_counter.py
+++ b/back-end/src/utils/title_word_counter.py
@@ -1,0 +1,6 @@
+from re import sub
+
+
+def count_title_words(title: str) -> int:
+    normalized_title = sub(r'[^\w\s]', '', title)
+    return len(normalized_title.split())

--- a/back-end/test/test_filtering_builder.py
+++ b/back-end/test/test_filtering_builder.py
@@ -1,0 +1,120 @@
+from typing import List
+from src.models.news_entry import NewsEntry
+from src.services.filtering.filtering_builder import FilterBuilder
+from src.utils.title_word_counter import count_title_words
+
+
+def has_the_same_order_by_number(entries: List[NewsEntry], other_entries: List[NewsEntry]) -> bool:
+    print(entries, other_entries)
+
+    if len(entries) != len(other_entries):
+        return False
+
+    for i in range(len(entries)):
+        if entries[i].number != other_entries[i].number:
+            return False
+
+    return True
+
+
+def test_filtering_builder_1() -> None:
+    entries = [
+        NewsEntry(
+            number=1,
+            title="News 1",
+            points=100,
+            comments_count=10
+        ),
+        NewsEntry(
+            number=2,
+            title="News 2",
+            points=200,
+            comments_count=20
+        ),
+        NewsEntry(
+            number=3,
+            title="News 3",
+            points=300,
+            comments_count=30
+        )
+    ]
+
+    builder = FilterBuilder(entries=entries)
+
+    filtered_entries = builder.where(
+        lambda entry: entry.title == "News 2"
+    ).execute_filter()
+
+    expected_entries = [entries[1]]
+
+    assert has_the_same_order_by_number(filtered_entries, expected_entries)
+
+
+def test_filtering_builder_filter_long_titles_order_by_comments() -> None:
+    entries = [
+        NewsEntry(number=1, title="This title has more than five words",
+                  points=100, comments_count=30),
+
+        NewsEntry(number=2, title="Short title",
+                  points=200, comments_count=20),
+
+        NewsEntry(number=3, title="Another long title with more than five words",
+                  points=150, comments_count=10),
+
+        NewsEntry(number=4, title="A title with exactly five words",
+                  points=300, comments_count=25),
+                  
+        NewsEntry(number=5, title="Shorter", points=250, comments_count=15),
+    ]
+
+    builder = FilterBuilder(entries=entries)
+
+    filtered_entries = builder.where(
+        lambda entry: count_title_words(entry.title) > 5
+    ).order_by(
+        lambda entry: entry.comments_count,
+        reverse=True
+    ).execute_filter()
+
+    expected_entries = [
+        entries[0],  # Title with more than five words and most comments
+        entries[3],  # Title with exactly five words and fewer comments
+        entries[2],  # Another long title with fewer comments
+    ]
+
+    assert has_the_same_order_by_number(filtered_entries, expected_entries)
+
+
+def test_filtering_builder_filter_short_titles_order_by_points() -> None:
+    entries = [
+        NewsEntry(number=1, title="This title has more than five words",
+                  points=100, comments_count=30),
+
+        NewsEntry(number=2, title="Short title",
+                  points=200, comments_count=20),
+
+        NewsEntry(number=3, title="Another long title with more than five words",
+                  points=150, comments_count=10),
+
+        NewsEntry(number=4, title="Title with exactly five words",
+                  points=300, comments_count=25),
+
+        NewsEntry(number=5, title="Shorter", points=250, comments_count=15),
+    ]
+
+    builder = FilterBuilder(entries=entries)
+
+    filtered_entries = builder.where(
+        lambda entry: count_title_words(entry.title) <= 5
+    ).order_by(
+        lambda entry: entry.points,
+        reverse=True
+    ).execute_filter()
+
+    expected_entries = [
+        entries[3],  # Short title with highest points
+        entries[4],  # Short title with lower points
+        entries[1],  # Short title with even lower points
+    ]
+
+    assert has_the_same_order_by_number(filtered_entries, expected_entries)

--- a/back-end/test/test_title_word_counter.py
+++ b/back-end/test/test_title_word_counter.py
@@ -1,0 +1,28 @@
+from src.utils.title_word_counter import count_title_words
+
+
+def test_count_title_words_1():
+    assert count_title_words("Hello, World!") == 2
+
+
+def test_count_title_words_2():
+    assert count_title_words("This is - a self-explained example") == 5
+
+
+def test_count_title_words_3():
+    assert count_title_words("A                 B ") == 2
+
+
+def test_count_title_words_4():
+    assert count_title_words("   ") == 0
+
+
+def test_count_title_words_5():
+    assert count_title_words("   Leading and trailing spaces   ") == 4
+
+
+def test_count_title_words_6():
+    assert count_title_words("Multiple!!! punctuation??? marks.") == 3
+
+def test_count_title_words_7():
+    assert count_title_words("á é") == 2

--- a/front-end/src/components/FilterSelector/FilterSelector.test.tsx
+++ b/front-end/src/components/FilterSelector/FilterSelector.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import FilterSelector from './FilterSelector';
+import { FilterType } from '../../types/FilterType';
+import '@testing-library/jest-dom';
+
+describe('FilterSelector', () => {
+	const mockOnFilterChange = jest.fn();
+
+	beforeEach(() => {
+		mockOnFilterChange.mockClear();
+	});
+
+	test('renders the buttons with default styles when no filter is selected', () => {
+		render(<FilterSelector onFilterChange={mockOnFilterChange} />);
+
+		const firstButton = screen.getByText(
+			'With more than 5 words in title ordered by number of comments',
+		).closest('button');
+		const secondButton = screen.getByText(
+			'With less than or equals to 5 words in title ordered by points',
+		).closest('button');
+
+		// Check that both buttons are in the default style
+		expect(firstButton).toHaveClass('ant-btn-default');
+		expect(secondButton).toHaveClass('ant-btn-default');
+	});
+
+	test('renders the first button as primary when the first filter is selected', () => {
+		render(
+			<FilterSelector
+				filter={FilterType.TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC}
+				onFilterChange={mockOnFilterChange}
+			/>,
+		);
+
+		const firstButton = screen.getByText(
+			'With more than 5 words in title ordered by number of comments',
+		).closest('button');
+
+		expect(firstButton).toHaveClass('ant-btn-primary');
+	});
+
+	test('calls onFilterChange with the correct filter when a button is clicked', () => {
+		render(<FilterSelector onFilterChange={mockOnFilterChange} />);
+
+		const firstButton = screen.getByText(
+			'With more than 5 words in title ordered by number of comments',
+		).closest('button');
+
+		fireEvent.click(firstButton!);
+
+		expect(mockOnFilterChange).toHaveBeenCalledWith(
+			FilterType.TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC,
+		);
+	});
+
+	test('toggles filter off when the button is clicked again', () => {
+		render(
+			<FilterSelector
+				filter={FilterType.TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC}
+				onFilterChange={mockOnFilterChange}
+			/>,
+		);
+
+		const firstButton = screen.getByText(
+			'With more than 5 words in title ordered by number of comments',
+		).closest('button');
+
+		fireEvent.click(firstButton!);
+
+		expect(mockOnFilterChange).toHaveBeenCalledWith(undefined);
+	});
+
+	test('renders the second button as primary when the second filter is selected', () => {
+		render(
+			<FilterSelector
+				filter={
+					FilterType.TITLE_WORDS_LESS_THAN_OR_EQUALS_TO_FIVE_ORDER_BY_POINTS_DESC
+				}
+				onFilterChange={mockOnFilterChange}
+			/>,
+		);
+
+		const secondButton = screen.getByText(
+			'With less than or equals to 5 words in title ordered by points',
+		).closest('button');
+
+		expect(secondButton).toHaveClass('ant-btn-primary');
+	});
+});

--- a/front-end/src/components/FilterSelector/FilterSelector.tsx
+++ b/front-end/src/components/FilterSelector/FilterSelector.tsx
@@ -1,0 +1,54 @@
+import { Button } from 'antd';
+import { FilterType } from '../../types/FilterType';
+
+interface FilterSelectorProps {
+	filter?: FilterType;
+	onFilterChange: (filter: FilterType | undefined) => void;
+}
+
+function FilterSelector({ filter, onFilterChange }: FilterSelectorProps) {
+	return (
+		<>
+			<Button
+                id='title-words-greater-than-five-order-by-comments-desc-button'
+				type={
+					filter ===
+					FilterType.TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC
+						? 'primary'
+						: 'default'
+				}
+				onClick={() =>
+					onFilterChange(
+						filter ===
+							FilterType.TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC
+							? undefined
+							: FilterType.TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC,
+					)
+				}
+			>
+				With more than 5 words in title ordered by number of comments
+			</Button>
+			<Button
+                id='title-words-less-than-or-equals-to-five-order-by-points-desc-button'
+				type={
+					filter ===
+					FilterType.TITLE_WORDS_LESS_THAN_OR_EQUALS_TO_FIVE_ORDER_BY_POINTS_DESC
+						? 'primary'
+						: 'default'
+				}
+				onClick={() =>
+					onFilterChange(
+						filter ===
+							FilterType.TITLE_WORDS_LESS_THAN_OR_EQUALS_TO_FIVE_ORDER_BY_POINTS_DESC
+							? undefined
+							: FilterType.TITLE_WORDS_LESS_THAN_OR_EQUALS_TO_FIVE_ORDER_BY_POINTS_DESC,
+					)
+				}
+			>
+				With less than or equals to 5 words in title ordered by points
+			</Button>
+		</>
+	);
+}
+
+export default FilterSelector;

--- a/front-end/src/pages/Entries/Entries.css
+++ b/front-end/src/pages/Entries/Entries.css
@@ -1,4 +1,13 @@
-.entries {
-    width: min(1100px, 100%);
-    margin: 0 auto;
+.container {
+	width: min(1100px, 100%);
+	margin: 0 auto;
+}
+
+.filters {
+	display: flex;
+	flex-direction: row;
+	gap: 1rem;
+	flex-wrap: wrap;
+    align-items: center;
+    margin-bottom: 1rem;
 }

--- a/front-end/src/pages/Entries/Entries.tsx
+++ b/front-end/src/pages/Entries/Entries.tsx
@@ -5,9 +5,14 @@ import NewsList from '../../components/NewsList/NewsList';
 
 import './Entries.css';
 import { Skeleton } from 'antd';
+import FilterSelector from '../../components/FilterSelector/FilterSelector';
+import { FilterType } from '../../types/FilterType';
 
 function Entries() {
 	const [news, setNews] = useState<NewsEntry[] | undefined | null>(null);
+	const [selectedFilter, setSelectedFilter] = useState<FilterType | undefined>(
+		undefined,
+	);
 
 	useEffect(() => {
 		axios
@@ -20,18 +25,43 @@ function Entries() {
 			});
 	}, []);
 
+	const onFilterChange = (filter: FilterType | undefined) => {
+		setSelectedFilter(filter);
+		setNews(null);
+
+		let apiRequestRoute = `/api/hacker-news-entries/`;
+
+		if (filter) {
+			apiRequestRoute += `?filter_request=${filter.toString()}`;
+		}
+
+		axios
+			.get<NewsEntry[]>(apiRequestRoute)
+			.then(response => {
+				setNews(response.data);
+			})
+			.catch(() => {
+				setNews(undefined);
+			});
+	};
+
 	return (
-		<>
-			<div className='entries'>
-				<Skeleton loading={news === null} active>
-					{(() => {
-						if (news !== null) {
-							return <NewsList news={news} />;
-						}
-					})()}
-				</Skeleton>
+		<div className='container'>
+			<div className='filters'>
+				<div>Filters:</div>
+				<FilterSelector
+					filter={selectedFilter}
+					onFilterChange={onFilterChange}
+				/>
 			</div>
-		</>
+			<Skeleton loading={news === null} active>
+				{(() => {
+					if (news !== null) {
+						return <NewsList news={news} />;
+					}
+				})()}
+			</Skeleton>
+		</div>
 	);
 }
 

--- a/front-end/src/types/FilterType.ts
+++ b/front-end/src/types/FilterType.ts
@@ -1,0 +1,4 @@
+export enum FilterType {
+    TITLE_WORDS_GREATER_THAN_FIVE_ORDER_BY_COMMENTS_DESC = "title_words_greater_than_five_order_by_comments_desc",
+    TITLE_WORDS_LESS_THAN_OR_EQUALS_TO_FIVE_ORDER_BY_POINTS_DESC = "title_words_less_than_or_equals_to_five_order_by_points_desc"
+}


### PR DESCRIPTION
This PR contains all the functionality to filters entries got in the Hacker News web scraping feature.

The implemented filters are:

- Filter all previous entries with more than five words in the title ordered by the number of comments first.
- Filter all previous entries with less than or equal to five words in the title ordered by points.